### PR TITLE
fix: improve syntax detection

### DIFF
--- a/test/basic.css
+++ b/test/basic.css
@@ -49,3 +49,21 @@ div {
 		(min-width: 600px) rgba(1, 2, 3)
 	);
 }
+
+p {
+	width: media(
+		100%/2,
+		(min-width: 600px) 100%/3
+	);
+}
+
+del {
+	width: media(
+		100% / 2,
+		(min-width: 600px) 100 % / 3
+	);
+}
+
+em {
+	width: media();
+}

--- a/test/basic.expect.css
+++ b/test/basic.expect.css
@@ -75,3 +75,27 @@ div {
 		color: rgba(1, 2, 3);
 	}
 }
+
+p {
+	width: 100%/2;
+}
+
+@media (min-width: 600px) {
+	p {
+		width: 100%/3;
+	}
+}
+
+del {
+	width: 100%/2;
+}
+
+@media (min-width: 600px) {
+	del {
+		width: 100%/3;
+	}
+}
+
+em {
+	width: media();
+}


### PR DESCRIPTION
allow to use more advanced syntax:

```css
del {
  width: media(
    100% / 2,
    (min-width: 600px) 100 % / 3
  );
}
```